### PR TITLE
fix issue with breakage in OC 17-18 due to change of group admin.

### DIFF
--- a/settings/admin.php
+++ b/settings/admin.php
@@ -11,7 +11,9 @@
 
 use OCA\ocDownloader\Controller\Lib\Settings;
 
-\OC_Util::checkAdminUser();
+if (!OC_User::isAdminUser(OC_User::getUser())) {
+   return;
+}
 
 // Display template
 \OCP\Util::addStyle('ocdownloader', 'settings/admin');


### PR DESCRIPTION
CheckAdminUser() redirects to /apps/files if a user start settings/user AND is a GroupAdmin for some group AND not a full Admin.

See also issue:
nextcloud/server#18865